### PR TITLE
Damage calculation tweaks

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,14 @@
+export const DICE_VALUES = {
+  HIT: 6,
+  MISS: 1,
+  RIFT_SELF_DAMAGE: 1,
+  RIFT_MISS_1: 2,
+  RIFT_MISS_2: 3,
+};
+
+export const HIT_AFTER_MODIFIERS = 6;
+
+export const GUARANTEED_HIT = () => DICE_VALUES.HIT;
+export const GUARANTEED_MISS = () => DICE_VALUES.MISS;
+export const RIFT_SELF_DAMAGE = () => DICE_VALUES.RIFT_SELF_DAMAGE;
+export const RIFT_MISS = () => DICE_VALUES.RIFT_MISS_1;

--- a/src/engine/battle.ts
+++ b/src/engine/battle.ts
@@ -1,3 +1,4 @@
+import { DICE_VALUES } from 'src/constants';
 import { Fleet } from './fleet';
 import { RiftShot, Ship } from './ship';
 
@@ -125,7 +126,7 @@ export class Battle {
       if (rift.selfDamage > 0) {
         firingFleet.assignDamage([
           {
-            roll: 6,
+            roll: DICE_VALUES.HIT,
             computers: 0,
             damage: rift.selfDamage,
           },
@@ -134,7 +135,7 @@ export class Battle {
       if (rift.targetDamage > 0) {
         targetFleet.assignDamage([
           {
-            roll: 6,
+            roll: DICE_VALUES.HIT,
             computers: 0,
             damage: rift.targetDamage,
           },

--- a/src/engine/combat-simulator.test.ts
+++ b/src/engine/combat-simulator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { CombatSimulator } from './combat-simulator';
 import { Fleet } from './fleet';
 import { Ship, ShipType } from './ship';
+import { DICE_VALUES, GUARANTEED_HIT, GUARANTEED_MISS } from 'src/constants';
 
 describe('CombatSimulator', () => {
   describe('simulate', () => {
@@ -13,14 +14,14 @@ describe('CombatSimulator', () => {
             hull: 5,
             cannons: { plasma: 3 },
           },
-          () => 6
+          GUARANTEED_HIT
         ),
       ]);
       const fleetB = new Fleet('Medium', [
-        new Ship(ShipType.Interceptor, { hull: 1 }, () => 1),
+        new Ship(ShipType.Interceptor, { hull: 1 }, GUARANTEED_MISS),
       ]);
       const fleetC = new Fleet('Weak', [
-        new Ship(ShipType.Interceptor, {}, () => 1),
+        new Ship(ShipType.Interceptor, {}, GUARANTEED_MISS),
       ]);
 
       const simulator = new CombatSimulator();
@@ -34,20 +35,20 @@ describe('CombatSimulator', () => {
 
     test('tracks expected survivors by type', () => {
       const fleetA = new Fleet('Mixed', [
-        new Ship(ShipType.Interceptor, { cannons: { ion: 1 } }, () => 6),
+        new Ship(ShipType.Interceptor, { cannons: { ion: 1 } }, GUARANTEED_HIT),
         new Ship(
           ShipType.Cruiser,
           { hull: 2, cannons: { plasma: 2 } },
-          () => 6
+          GUARANTEED_HIT
         ),
         new Ship(
           ShipType.Dreadnaught,
           { hull: 3, cannons: { antimatter: 2 } },
-          () => 6
+          GUARANTEED_HIT
         ),
       ]);
       const fleetB = new Fleet('Weak', [
-        new Ship(ShipType.Interceptor, {}, () => 1),
+        new Ship(ShipType.Interceptor, {}, GUARANTEED_MISS),
       ]);
 
       const simulator = new CombatSimulator();
@@ -73,13 +74,13 @@ describe('CombatSimulator', () => {
 
     test('handles draws correctly', () => {
       const fleetA = new Fleet('Rift A', [
-        new Ship(ShipType.Cruiser, { hull: 0, rift: 1 }, () => 6),
+        new Ship(ShipType.Cruiser, { hull: 0, rift: 1 }, GUARANTEED_HIT),
       ]);
       const fleetB = new Fleet('Rift B', [
-        new Ship(ShipType.Interceptor, { hull: 2 }, () => 1),
+        new Ship(ShipType.Interceptor, { hull: 2 }, GUARANTEED_MISS),
       ]);
       const fleetC = new Fleet('Survivor', [
-        new Ship(ShipType.Interceptor, { cannons: { ion: 1 } }, () => 6),
+        new Ship(ShipType.Interceptor, { cannons: { ion: 1 } }, GUARANTEED_HIT),
       ]);
 
       const simulator = new CombatSimulator();
@@ -96,7 +97,8 @@ describe('CombatSimulator', () => {
 
     test('handles variable outcomes', () => {
       let rollCount = 0;
-      const rolls = [6, 6, 1, 1, 1, 1];
+      const { HIT, MISS } = DICE_VALUES;
+      const rolls = [HIT, HIT, MISS, MISS, MISS, MISS];
 
       const fleetA = new Fleet('Variable', [
         new Ship(
@@ -115,7 +117,7 @@ describe('CombatSimulator', () => {
             hull: 1,
             cannons: { ion: 1 },
           },
-          () => 6
+          GUARANTEED_HIT
         ),
       ]);
 

--- a/src/engine/fleet.test.ts
+++ b/src/engine/fleet.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Ship, ShipType, Shot } from './ship';
 import { Fleet } from './fleet';
+import { DICE_VALUES, GUARANTEED_HIT, RIFT_MISS } from 'src/constants';
 
 describe('Fleet', () => {
   describe('getInitiatives', () => {
@@ -45,11 +46,15 @@ describe('Fleet', () => {
     {
       name: 'single ship with weapons',
       ships: [
-        new Ship(ShipType.Interceptor, {
-          initiative: 3,
-          missiles: { ion: 2 },
-          cannons: { plasma: 1 },
-        }),
+        new Ship(
+          ShipType.Interceptor,
+          {
+            initiative: 3,
+            missiles: { ion: 2 },
+            cannons: { plasma: 1 },
+          },
+          GUARANTEED_HIT
+        ),
       ],
       initiative: 3,
       expectedMissileCount: 2,
@@ -58,21 +63,33 @@ describe('Fleet', () => {
     {
       name: 'multiple ships at same initiative',
       ships: [
-        new Ship(ShipType.Interceptor, {
-          initiative: 3,
-          missiles: { ion: 1 },
-          cannons: { ion: 1 },
-        }),
-        new Ship(ShipType.Cruiser, {
-          initiative: 3,
-          missiles: { plasma: 2 },
-          cannons: { plasma: 2 },
-        }),
-        new Ship(ShipType.Dreadnaught, {
-          initiative: 2,
-          missiles: { antimatter: 1 },
-          cannons: { antimatter: 1 },
-        }),
+        new Ship(
+          ShipType.Interceptor,
+          {
+            initiative: 3,
+            missiles: { ion: 1 },
+            cannons: { ion: 1 },
+          },
+          GUARANTEED_HIT
+        ),
+        new Ship(
+          ShipType.Cruiser,
+          {
+            initiative: 3,
+            missiles: { plasma: 2 },
+            cannons: { plasma: 2 },
+          },
+          GUARANTEED_HIT
+        ),
+        new Ship(
+          ShipType.Dreadnaught,
+          {
+            initiative: 2,
+            missiles: { antimatter: 1 },
+            cannons: { antimatter: 1 },
+          },
+          GUARANTEED_HIT
+        ),
       ],
       initiative: 3,
       expectedMissileCount: 3,
@@ -81,12 +98,16 @@ describe('Fleet', () => {
     {
       name: 'dead ships dont shoot',
       ships: [
-        new Ship(ShipType.Interceptor, {
-          initiative: 3,
-          missiles: { ion: 2 },
-          cannons: { ion: 2 },
-          hull: 1,
-        }),
+        new Ship(
+          ShipType.Interceptor,
+          {
+            initiative: 3,
+            missiles: { ion: 2 },
+            cannons: { ion: 2 },
+            hull: 1,
+          },
+          GUARANTEED_HIT
+        ),
       ],
       initiative: 3,
       setupFleet: (fleet: Fleet) => {
@@ -116,11 +137,15 @@ describe('Fleet', () => {
     );
 
     test('only shoots missiles', () => {
-      const ship = new Ship(ShipType.Interceptor, {
-        initiative: 3,
-        missiles: { ion: 2 },
-        cannons: { plasma: 3 },
-      });
+      const ship = new Ship(
+        ShipType.Interceptor,
+        {
+          initiative: 3,
+          missiles: { ion: 2 },
+          cannons: { plasma: 3 },
+        },
+        GUARANTEED_HIT
+      );
       const fleet = new Fleet('test', [ship]);
 
       const shots = fleet.shootMissilesForInitiative(3);
@@ -152,11 +177,15 @@ describe('Fleet', () => {
     );
 
     test('only shoots cannons', () => {
-      const ship = new Ship(ShipType.Interceptor, {
-        initiative: 3,
-        missiles: { ion: 2 },
-        cannons: { plasma: 3 },
-      });
+      const ship = new Ship(
+        ShipType.Interceptor,
+        {
+          initiative: 3,
+          missiles: { ion: 2 },
+          cannons: { plasma: 3 },
+        },
+        GUARANTEED_HIT
+      );
       const fleet = new Fleet('test', [ship]);
 
       const shots = fleet.shootCannonsForInitiative(3);
@@ -179,10 +208,14 @@ describe('Fleet', () => {
       {
         name: 'single ship with rift',
         ships: [
-          new Ship(ShipType.Cruiser, {
-            initiative: 2,
-            rift: 2,
-          }),
+          new Ship(
+            ShipType.Cruiser,
+            {
+              initiative: 2,
+              rift: 2,
+            },
+            GUARANTEED_HIT
+          ),
         ],
         initiative: 2,
         expectedShotCount: 2,
@@ -190,14 +223,30 @@ describe('Fleet', () => {
       {
         name: 'multiple ships with rift',
         ships: [
-          new Ship(ShipType.Dreadnaught, {
-            initiative: 1,
-            rift: 1,
-          }),
-          new Ship(ShipType.Cruiser, {
-            initiative: 1,
-            rift: 3,
-          }),
+          new Ship(
+            ShipType.Dreadnaught,
+            {
+              initiative: 1,
+              rift: 1,
+            },
+            GUARANTEED_HIT
+          ),
+          new Ship(
+            ShipType.Cruiser,
+            {
+              initiative: 1,
+              rift: 3,
+            },
+            GUARANTEED_HIT
+          ),
+          new Ship(
+            ShipType.Cruiser,
+            {
+              initiative: 1,
+              rift: 3,
+            },
+            RIFT_MISS
+          ),
         ],
         initiative: 1,
         expectedShotCount: 4,
@@ -219,7 +268,7 @@ describe('Fleet', () => {
 
       const shots: Shot[] = [
         {
-          roll: 6,
+          roll: DICE_VALUES.HIT,
           computers: 0,
           damage: 3,
         },
@@ -239,7 +288,7 @@ describe('Fleet', () => {
 
       const shots: Shot[] = [
         {
-          roll: 6,
+          roll: DICE_VALUES.HIT,
           computers: 0,
           damage: 1,
         },
@@ -259,7 +308,7 @@ describe('Fleet', () => {
 
       const shots: Shot[] = [
         {
-          roll: 6,
+          roll: DICE_VALUES.HIT,
           computers: 0,
           damage: 1,
         },
@@ -297,8 +346,8 @@ describe('Fleet', () => {
       const fleet = new Fleet('test', [ship1, ship2]);
 
       const shots: Shot[] = [
-        { roll: 6, computers: 0, damage: 2 },
-        { roll: 6, computers: 0, damage: 2 },
+        { roll: DICE_VALUES.HIT, computers: 0, damage: 2 },
+        { roll: DICE_VALUES.HIT, computers: 0, damage: 2 },
       ];
 
       fleet.assignDamage(shots);
@@ -416,7 +465,7 @@ describe('Fleet', () => {
           initiative: 3,
           cannons: { antimatter: 1 },
         },
-        () => 6
+        GUARANTEED_HIT
       );
 
       // Override shootCannons to capture the flag
@@ -441,14 +490,14 @@ describe('Fleet', () => {
           initiative: 2,
           cannons: { antimatter: 1 },
         },
-        () => 5
+        GUARANTEED_HIT
       );
 
       const fleetWithSplitter = new Fleet('test', [ship], true);
       const shots = fleetWithSplitter.shootCannonsForInitiative(2);
 
       expect(shots.length).toBe(4);
-      expect(shots.every((shot) => shot.roll === 5)).toBe(true);
+      expect(shots.every((shot) => shot.roll === DICE_VALUES.HIT)).toBe(true);
       expect(shots.every((shot) => shot.damage === 1)).toBe(true);
     });
   });

--- a/src/engine/multi-battle.test.ts
+++ b/src/engine/multi-battle.test.ts
@@ -3,6 +3,11 @@ import { MultiBattle } from './multi-battle';
 import { BattleOutcome } from './battle';
 import { Fleet } from './fleet';
 import { Ship, ShipType } from './ship';
+import {
+  GUARANTEED_HIT,
+  GUARANTEED_MISS,
+  RIFT_SELF_DAMAGE,
+} from 'src/constants';
 
 describe('MultiBattle', () => {
   describe('constructor', () => {
@@ -27,10 +32,10 @@ describe('MultiBattle', () => {
   describe('run', () => {
     test('single battle between two fleets', () => {
       const defender = new Fleet('defender', [
-        new Ship(ShipType.Interceptor, { hull: 1 }, () => 1),
+        new Ship(ShipType.Interceptor, { hull: 1 }, GUARANTEED_MISS),
       ]);
       const attacker = new Fleet('attacker', [
-        new Ship(ShipType.Interceptor, { cannons: { ion: 2 } }, () => 6),
+        new Ship(ShipType.Interceptor, { cannons: { ion: 2 } }, GUARANTEED_HIT),
       ]);
 
       const multiBattle = new MultiBattle([defender, attacker]);
@@ -43,13 +48,17 @@ describe('MultiBattle', () => {
 
     test('three fleets - winner faces next challenger', () => {
       const defender = new Fleet('defender', [
-        new Ship(ShipType.Interceptor, { cannons: { ion: 1 } }, () => 1),
+        new Ship(
+          ShipType.Interceptor,
+          { cannons: { ion: 1 } },
+          GUARANTEED_MISS
+        ),
       ]);
       const attacker1 = new Fleet('attacker1', [
-        new Ship(ShipType.Interceptor, { cannons: { ion: 2 } }, () => 6),
+        new Ship(ShipType.Interceptor, { cannons: { ion: 2 } }, GUARANTEED_HIT),
       ]);
       const attacker2 = new Fleet('attacker2', [
-        new Ship(ShipType.Interceptor, { hull: 1 }, () => 1),
+        new Ship(ShipType.Interceptor, { hull: 1 }, GUARANTEED_MISS),
       ]);
 
       const multiBattle = new MultiBattle([defender, attacker1, attacker2]);
@@ -62,10 +71,10 @@ describe('MultiBattle', () => {
 
     test('stalemate is victory for defender', () => {
       const defender = new Fleet('defender', [
-        new Ship(ShipType.Interceptor, {}, () => 1),
+        new Ship(ShipType.Interceptor, {}, GUARANTEED_MISS),
       ]);
       const attacker = new Fleet('attacker', [
-        new Ship(ShipType.Interceptor, {}, () => 1),
+        new Ship(ShipType.Interceptor, {}, GUARANTEED_MISS),
       ]);
 
       const multiBattle = new MultiBattle([defender, attacker]);
@@ -78,14 +87,14 @@ describe('MultiBattle', () => {
     test('draw removes both fleets', () => {
       const defender = new Fleet('defender', [new Ship(ShipType.Interceptor)]);
       const attacker1 = new Fleet('attacker1', [
-        new Ship(ShipType.Interceptor, { hull: 2 }, () => 1),
+        new Ship(ShipType.Interceptor, { hull: 2 }, GUARANTEED_MISS),
       ]);
       const attacker2 = new Fleet('attacker2', [
         new Ship(
           ShipType.Cruiser,
           { hull: 0, rift: 1 },
-          // Rift roll 6 = 1 self damage, 3 target damage
-          () => 6
+          // Rift roll 1 self damage, 3 target damage
+          GUARANTEED_HIT
         ),
       ]);
 
@@ -108,7 +117,7 @@ describe('MultiBattle', () => {
             hull: 3,
             cannons: { ion: 2 },
           },
-          () => 6
+          GUARANTEED_HIT
         ),
       ]);
 
@@ -119,7 +128,7 @@ describe('MultiBattle', () => {
             hull: 1,
             cannons: { ion: 1 },
           },
-          () => 6
+          GUARANTEED_HIT
         ),
       ]);
 
@@ -130,7 +139,7 @@ describe('MultiBattle', () => {
             hull: 2,
             cannons: { ion: 2 },
           },
-          () => 6
+          GUARANTEED_HIT
         ),
       ]);
 
@@ -144,10 +153,10 @@ describe('MultiBattle', () => {
 
     test('empty result when all fleets eliminated', () => {
       const defender = new Fleet('defender', [
-        new Ship(ShipType.Interceptor, { hull: 1 }, () => 1),
+        new Ship(ShipType.Interceptor, { hull: 1 }, GUARANTEED_MISS),
       ]);
       const attacker = new Fleet('attacker', [
-        new Ship(ShipType.Interceptor, { hull: 1, rift: 1 }, () => 5), // Self-destructs
+        new Ship(ShipType.Interceptor, { hull: 1, rift: 1 }, RIFT_SELF_DAMAGE), // Self-destructs
       ]);
 
       const multiBattle = new MultiBattle([defender, attacker]);
@@ -166,33 +175,33 @@ describe('MultiBattle', () => {
           new Ship(
             ShipType.Interceptor,
             { initiative: 3, cannons: { ion: 1 } },
-            () => 6
+            GUARANTEED_HIT
           ),
           new Ship(
             ShipType.Interceptor,
             { initiative: 3, cannons: { ion: 1 } },
-            () => 6
+            GUARANTEED_HIT
           ),
         ]),
         new Fleet('Attacker1', [
           new Ship(
             ShipType.Interceptor,
             { initiative: 2, cannons: { ion: 1 } },
-            () => 6
+            GUARANTEED_HIT
           ),
         ]),
         new Fleet('Attacker2', [
           new Ship(
             ShipType.Cruiser,
             { initiative: 1, hull: 2, missiles: { plasma: 2 } },
-            () => 6
+            GUARANTEED_HIT
           ),
         ]),
         new Fleet('Attacker3', [
           new Ship(
             ShipType.Dreadnaught,
             { initiative: 1, hull: 3, cannons: { antimatter: 2 } },
-            () => 6
+            GUARANTEED_HIT
           ),
         ]),
       ];

--- a/src/engine/ship.test.ts
+++ b/src/engine/ship.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { Ship, ShipType, Shot, WeaponDamage, WeaponType } from './ship';
+import { DICE_VALUES, GUARANTEED_HIT } from 'src/constants';
 
 describe('Ship', () => {
   describe('isPlayerShip', () => {
@@ -91,7 +92,7 @@ describe('Ship', () => {
       [WeaponDamage.antimatter]: 0,
     };
     shots.forEach((shot) => {
-      expect(shot.roll).toEqual(6);
+      expect(shot.roll).toEqual(DICE_VALUES.HIT);
       expect(shot.computers).toEqual(computers);
       shotCountByDamage[shot.damage]++;
     });
@@ -111,7 +112,7 @@ describe('Ship', () => {
           missiles: weapons,
           computers: 1,
         },
-        () => 6
+        GUARANTEED_HIT
       );
       const shots = ship.shootMissles();
       validateShots(ship.computers, ship.missiles, shots);
@@ -126,7 +127,7 @@ describe('Ship', () => {
           cannons: weapons,
           computers: 1,
         },
-        () => 6
+        GUARANTEED_HIT
       );
       const shots = ship.shootCannons();
       validateShots(ship.computers, ship.cannons, shots);
@@ -167,7 +168,7 @@ describe('Ship', () => {
           cannons: { ion: 1, plasma: 1, soliton: 0, antimatter: 0 },
           computers: 1,
         },
-        () => 6
+        GUARANTEED_HIT
       );
 
       const shots = ship.shootCannons(true);
@@ -178,12 +179,12 @@ describe('Ship', () => {
     });
 
     test('handles multiple antimatter cannons', () => {
-      let rollCount = 0;
+      let rollCount = DICE_VALUES.HIT - 2;
       const ship = new Ship(
         ShipType.Interceptor,
         {
           cannons: { ion: 0, plasma: 0, soliton: 0, antimatter: 2 },
-          computers: 0,
+          computers: 1,
         },
         () => ++rollCount
       );
@@ -191,8 +192,12 @@ describe('Ship', () => {
       const shots = ship.shootCannons(true);
 
       expect(shots.length).toBe(8);
-      expect(shots.slice(0, 4).every((shot) => shot.roll === 1)).toBe(true);
-      expect(shots.slice(4, 8).every((shot) => shot.roll === 2)).toBe(true);
+      expect(
+        shots.slice(0, 4).every((shot) => shot.roll === DICE_VALUES.HIT - 1)
+      ).toBe(true);
+      expect(
+        shots.slice(4, 8).every((shot) => shot.roll === DICE_VALUES.HIT)
+      ).toBe(true);
       expect(shots.every((shot) => shot.damage === 1)).toBe(true);
     });
 
@@ -221,13 +226,13 @@ describe('Ship', () => {
           missiles: { ion: 0, plasma: 0, soliton: 0, antimatter: 1 },
           computers: 2,
         },
-        () => 5
+        () => DICE_VALUES.HIT - 1
       );
 
       const shots = ship.shootMissles();
 
       expect(shots.length).toBe(1);
-      expect(shots[0].roll).toBe(5);
+      expect(shots[0].roll).toBe(DICE_VALUES.HIT - 1);
       expect(shots[0].damage).toBe(WeaponDamage.antimatter);
     });
   });
@@ -235,42 +240,34 @@ describe('Ship', () => {
   describe('shootRiftCannon', () => {
     test.each([
       {
-        roll: 1,
-        expected: {
-          selfDamage: 0,
-          targetDamage: 0,
-        },
-      },
-      {
-        roll: 2,
-        expected: {
-          selfDamage: 0,
-          targetDamage: 0,
-        },
-      },
-      {
-        roll: 3,
-        expected: {
-          selfDamage: 0,
-          targetDamage: 1,
-        },
-      },
-      {
-        roll: 4,
-        expected: {
-          selfDamage: 0,
-          targetDamage: 2,
-        },
-      },
-      {
-        roll: 5,
+        roll: DICE_VALUES.RIFT_SELF_DAMAGE,
         expected: {
           selfDamage: 1,
           targetDamage: 0,
         },
       },
       {
-        roll: 6,
+        roll: 2,
+      },
+      {
+        roll: 3,
+      },
+      {
+        roll: 4,
+        expected: {
+          selfDamage: 0,
+          targetDamage: 1,
+        },
+      },
+      {
+        roll: 5,
+        expected: {
+          selfDamage: 0,
+          targetDamage: 2,
+        },
+      },
+      {
+        roll: DICE_VALUES.HIT,
         expected: {
           selfDamage: 1,
           targetDamage: 3,
@@ -285,12 +282,16 @@ describe('Ship', () => {
         () => roll
       );
       const riftShots = ship.shootRiftCannon();
-      expect(riftShots.length).toEqual(1);
-      expect(riftShots[0]).toEqual(expected);
+      if (expected) {
+        expect(riftShots.length).toEqual(1);
+        expect(riftShots[0]).toEqual(expected);
+      } else {
+        expect(riftShots.length).toEqual(0);
+      }
     });
 
     test('shoots the right number of shots', () => {
-      const ship = new Ship(ShipType.Interceptor, { rift: 3 });
+      const ship = new Ship(ShipType.Interceptor, { rift: 3 }, GUARANTEED_HIT);
       const riftShots = ship.shootRiftCannon();
       expect(riftShots.length).toEqual(3);
     });
@@ -351,7 +352,7 @@ describe('Ship', () => {
       {
         name: '6 hits',
         shot: {
-          roll: 6,
+          roll: DICE_VALUES.HIT,
           computers: 0,
           damage: 1,
         },
@@ -361,7 +362,7 @@ describe('Ship', () => {
       {
         name: '5 hits with computers',
         shot: {
-          roll: 6,
+          roll: DICE_VALUES.HIT,
           computers: 1,
           damage: 1,
         },
@@ -371,7 +372,7 @@ describe('Ship', () => {
       {
         name: '5 misses with computers and shields',
         shot: {
-          roll: 0,
+          roll: DICE_VALUES.MISS,
           computers: 1,
           damage: 1,
         },
@@ -413,6 +414,74 @@ describe('Ship', () => {
       ship.takeDamage(10);
       expect(ship.remainingHP()).toEqual(0);
       expect(ship.isAlive()).toEqual(false);
+    });
+  });
+
+  describe('hasCannons', () => {
+    test('detects when cannons present', () => {
+      const ship = new Ship(ShipType.Interceptor, { cannons: { ion: 1 } });
+      expect(ship.hasCannons()).toEqual(true);
+    });
+
+    test('detects when no cannons present', () => {
+      const ship = new Ship(ShipType.Interceptor, {
+        missiles: { ion: 1, plasma: 1, soliton: 1, antimatter: 1 },
+      });
+      expect(ship.hasCannons()).toEqual(false);
+    });
+
+    test('detects when multiple cannons present', () => {
+      const ship = new Ship(ShipType.Interceptor, {
+        cannons: { ion: 1, plasma: 1, soliton: 1, antimatter: 1 },
+      });
+      expect(ship.hasCannons()).toEqual(true);
+    });
+
+    test('detects when rift cannons present', () => {
+      const ship = new Ship(ShipType.Interceptor, { rift: 1 });
+      expect(ship.hasCannons()).toEqual(true);
+    });
+
+    test('detects when cannons and missiles present', () => {
+      const ship = new Ship(ShipType.Interceptor, {
+        cannons: { ion: 1 },
+        missiles: { ion: 1 },
+      });
+      expect(ship.hasCannons()).toEqual(true);
+    });
+  });
+
+  describe('hasMissiles', () => {
+    test('detects when missiles present', () => {
+      const ship = new Ship(ShipType.Interceptor, { missiles: { ion: 1 } });
+      expect(ship.hasMissiles()).toEqual(true);
+    });
+
+    test('detects when no missiles present', () => {
+      const ship = new Ship(ShipType.Interceptor, {
+        cannons: { ion: 1, plasma: 1, soliton: 1, antimatter: 1 },
+      });
+      expect(ship.hasMissiles()).toEqual(false);
+    });
+
+    test('detects when multiple missiles present', () => {
+      const ship = new Ship(ShipType.Interceptor, {
+        missiles: { ion: 1, plasma: 1, soliton: 1, antimatter: 1 },
+      });
+      expect(ship.hasMissiles()).toEqual(true);
+    });
+
+    test('detects when false when only rift present', () => {
+      const ship = new Ship(ShipType.Interceptor, { rift: 1 });
+      expect(ship.hasMissiles()).toEqual(false);
+    });
+
+    test('detects when cannons and missiles present', () => {
+      const ship = new Ship(ShipType.Interceptor, {
+        cannons: { ion: 1 },
+        missiles: { ion: 1 },
+      });
+      expect(ship.hasMissiles()).toEqual(true);
     });
   });
 });

--- a/src/engine/ship.ts
+++ b/src/engine/ship.ts
@@ -1,3 +1,5 @@
+import { DICE_VALUES, HIT_AFTER_MODIFIERS } from 'src/constants';
+
 type ValueOf<T> = T[keyof T];
 
 export const ShipType = {
@@ -106,8 +108,8 @@ export class Ship {
     return !npcTypes.includes(this.type);
   }
 
-  shootMissles(): Shot[] {
-    return this.rollWeapons(this.missiles);
+  shootMissles(antimatterSplitter: boolean = false): Shot[] {
+    return this.rollWeapons(this.missiles, antimatterSplitter);
   }
 
   shootCannons(antimatterSplitter: boolean = false): Shot[] {
@@ -124,6 +126,9 @@ export class Ship {
 
       for (let i = 0; i < count; i++) {
         const roll = this.rollD6();
+        if (roll + this.computers < 6) {
+          continue;
+        }
         const weaponDamage = WeaponDamage[type];
 
         if (type === WeaponType.Antimatter && antimatterSplitter) {
@@ -151,36 +156,24 @@ export class Ship {
 
     for (let i = 0; i < this.rift; i++) {
       const roll = this.rollD6();
-      let selfDamage = 0;
-      let targetDamage = 0;
-      switch (roll) {
-        case 3:
-          targetDamage = 1;
-          break;
-        case 4:
-          targetDamage = 2;
-          break;
-        case 5:
-          selfDamage = 1;
-          break;
-        case 6:
-          selfDamage = 1;
-          targetDamage = 3;
-          break;
+      const selfDamage =
+        roll === 6 || roll === DICE_VALUES.RIFT_SELF_DAMAGE ? 1 : 0;
+      const targetDamage = Math.max(0, roll - 3);
+      if (selfDamage > 0 || targetDamage > 0) {
+        shots.push({ selfDamage, targetDamage });
       }
-      shots.push({ selfDamage, targetDamage });
     }
     return shots;
   }
 
   shotHits(shot: Shot): boolean {
-    if (shot.roll === 1) {
+    if (shot.roll === DICE_VALUES.MISS) {
       return false;
     }
-    if (shot.roll === 6) {
+    if (shot.roll === DICE_VALUES.HIT) {
       return true;
     }
-    return shot.roll + shot.computers - this.shields >= 6;
+    return shot.roll + shot.computers - this.shields >= HIT_AFTER_MODIFIERS;
   }
 
   shotKills(shot: Shot): boolean {
@@ -209,5 +202,9 @@ export class Ship {
     );
     const hasRift = this.rift > 0;
     return hasRegularCannons || hasRift;
+  }
+
+  hasMissiles(): boolean {
+    return Object.values(this.missiles).some((count) => count > 0);
   }
 }


### PR DESCRIPTION
Looking at making it easier to calculate all the permutations of damage without using dice that don't matter :)

Substantive changes
- For damage calculations, only return shots that have an impact on the battle (ignore misses and shots that can't hit even with computers added in), so there are fewer values to deal with in later calculations.
- Change up the rift calculations to use 1 for self damage and 4/5/6 for target damage

Refactoring
- Extract constants to a separate file