### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fivethirty/luminary/security/code-scanning/1](https://github.com/fivethirty/luminary/security/code-scanning/1)

To fix this problem, an explicit `permissions` block must be added to the workflow to restrict the permissions of the GITHUB_TOKEN. Since the job consists of only read-only operations (checking out code, installing dependencies, running lint/typecheck/tests, and caching dependencies), the GITHUB_TOKEN should only require `contents: read`. The ideal fix is to add `permissions:\n  contents: read` at the top-level of the workflow (just after the `name:` or before/after the `on:` block), applying to all jobs in the workflow unless overridden. This change should be added to `.github/workflows/test.yml` without changing any existing steps or logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
